### PR TITLE
Update distributor image and imagePullPolicy

### DIFF
--- a/event-distributor/values.yaml
+++ b/event-distributor/values.yaml
@@ -32,7 +32,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.8.1"
+  tag: "v0.8.3-rc"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/genai-toolkit-helmcharts/templates/api.yaml
+++ b/genai-toolkit-helmcharts/templates/api.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: genai-toolkit-api
           image: {{ .Values.dockerRegistry }}genai-toolkit-api:{{ .Chart.Version }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 8001
               protocol: TCP

--- a/genai-toolkit-helmcharts/templates/rag-api.yaml
+++ b/genai-toolkit-helmcharts/templates/rag-api.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: genai-toolkit-rag-api
           image: {{ .Values.dockerRegistry }}genai-toolkit-rag-api:{{ .Chart.Version }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 8002
               protocol: TCP

--- a/genai-toolkit-helmcharts/templates/ui.yaml
+++ b/genai-toolkit-helmcharts/templates/ui.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: genai-toolkit-ui
           image: {{ .Values.dockerRegistry }}genai-toolkit-ui:{{ .Chart.Version }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000
               protocol: TCP


### PR DESCRIPTION
Switching to Always for our images. I had a 0.8.1 UI pod that was not the same as the published version (probably from pushing images locally when I was working on the debug-queue stuff) and I kept seeing weird UI behavior (due to it being an old image now).

I figured as a default we should just always pull "our" images in case we ever need to swap out a broken/insecure version.

This PR also introduces the v0.8.3-rc version of distributor - the first version built as a bun compiled binary.
If you want more logging than what it provides by default now - just delete or set `NODE_ENV` to anything but "production" in  https://github.com/NetAppLabs/genai-toolkit-deployments/blob/9cd34af1223a283d68b67748bc3bb5a648045f07/event-distributor/values.yaml#L26